### PR TITLE
Configure subgraph + add rinkeby contract addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Full Description
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
 
+wPOKT on Rinkeby - `0x2f363dd061cc8b3411c3c91c0cfac0fa1b62f656`
+TokenGeyser on Rinkeby - `0xdb7d0a3bfcb7b34e6be510b26c55c8b60bd66d4a`
+wPOKT Pool - `0x7c2cf434e98940ad08ae3f26986235628b0904e7`
+
 ### Example usage
 
 ```

--- a/src/mappings/tokenGeyser.ts
+++ b/src/mappings/tokenGeyser.ts
@@ -1,0 +1,17 @@
+import {
+  Staked,
+  Unstaked,
+  TokensClaimed,
+  TokensLocked,
+  TokensUnlocked
+} from '../types/TokenGeyser/TokenGeyser';
+
+export function handleStaked(event: Staked): void {}
+
+export function handleUnstaked(event: Unstaked): void {}
+
+export function handleTokensClaimed(event: TokensClaimed): void {}
+
+export function handleTokensLocked(event: TokensLocked): void {}
+
+export function handleTokensUnlocked(event: TokensUnlocked): void {}

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,25 +1,36 @@
 specVersion: 0.0.2
-description: Example Subgraph
-repository: https://github.com/graphprotocol/example-subgraph
+description: wPOKT Farming Subgraph
+repository: https://github.com/pokt-network/wpokt-subgraph
 schema:
   file: ./schema.graphql
 dataSources:
   - kind: ethereum/contract
-    name: Example
-    network: mainnet
+    name: TokenGeyser
+    network: rinkeby
     source:
-      address: '0x0000000000000000000000000000000000000000'
-      abi: ExampleAbi
+      address: '0xdb7d0a3bfcb7b34e6be510b26c55c8b60bd66d4a'
+      abi: TokenGeyser
+      startBlock: 8078761
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4
       language: wasm/assemblyscript
       entities:
-        - Example
+        - TokenGeyser
       abis:
-        - name: ExampleAbi
-          file: ./abis/ExampleAbi.json
+        - name: TokenGeyser
+          file: ./abis/TokenGeyser.json
+        - name: ERC20
+          file: ./abis/ERC20.json
       eventHandlers:
-        - event: NewExample(uint256,address,string,string)
-          handler: handleNewExample
-      file: ./src/mapping.ts
+        - event: Staked(indexed address,uint256,uint256,bytes)
+          handler: handleStaked
+        - event: Unstaked(indexed address,uint256,uint256,bytes)
+          handler: handleUnstaked
+        - event: TokensClaimed(indexed address,uint256)
+          handler: handleTokensClaimed
+        - event: TokensLocked(uint256,uint256,uint256)
+          handler: handleTokensLocked
+        - event: TokensUnlocked(uint256,uint256)
+          handler: handleTokensUnlocked
+      file: ./src/mappings/tokenGeyser.ts


### PR DESCRIPTION
This adds the initial rinkeby configuration to the subgraph & core events.