### PR TITLE
Auth via deploy command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,10 +40,7 @@ jobs:
       - name: Install packages
         run: yarn install
       
-      - name: Authenticate on hosted service
+      - name: Deploy subgraph
         env: 
           GRAPH_TOKEN: ${{ secrets.GRAPH_TOKEN }}
-        run: yarn auth $GRAPH_TOKEN
-      
-      - name: Deploy subgraph
-        run: yarn deploy
+        run: yarn deploy $GRAPH_TOKEN

--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   "repository": "https://github.com/pokt-network/wpokt-subgraph",
   "license": "MIT",
   "scripts": {
-    "auth": "graph auth https://api.thegraph.com/",
     "codegen": "graph codegen --output-dir src/types/",
     "build": "graph build",
-    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ crisog/alpha-rinkeby-subgraph"
+    "deploy": "graph deploy crisog/alpha-rinkeby-subgraph --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ --access-token"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.18.0",


### PR DESCRIPTION
https://github.com/graphprotocol/graph-cli/issues/569

For some compatibility issues, we can no longer auth using graph CLI.