### PR TITLE
Configure mainnet/testnet subgraph deployment

### DIFF
--- a/.github/workflows/mainnet.yaml
+++ b/.github/workflows/mainnet.yaml
@@ -1,0 +1,31 @@
+name: Mainnet CI/CD
+
+on:
+  workflow_dispatch:
+
+env:
+  MAINNET_SUBGRAPH: pokt-network/wpokt-subgraph
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+          check-latest: true
+      
+      - name: Install packages
+        run: yarn install
+      
+      - name: Generate code for subgraph
+        run: yarn codegen
+      
+      - name: Build subgraph
+        run: yarn build
+
+      - name: Deploy mainnet subgraph
+        env: 
+          GRAPH_TOKEN: ${{ secrets.GRAPH_TOKEN }}
+        run: yarn deploy $GRAPH_TOKEN $MAINNET_SUBGRAPH

--- a/.github/workflows/testnet.yaml
+++ b/.github/workflows/testnet.yaml
@@ -1,11 +1,13 @@
-name: CI/CD
+name: Rinkeby CI/CD
 
 on:
   push:
     branches: [master]
   pull_request:
     branches: [master]
-  workflow_dispatch:
+
+env:
+  TESTNET_SUBGRAPH: crisog/alpha-rinkeby-subgraph
 
 jobs:
   ci:
@@ -26,8 +28,8 @@ jobs:
       - name: Build subgraph
         run: yarn build
 
-      - name: Deploy subgraph
+      - name: Deploy testnet subgraph
         if: ${{ github.event_name == 'push' }}
         env: 
           GRAPH_TOKEN: ${{ secrets.GRAPH_TOKEN }}
-        run: yarn deploy $GRAPH_TOKEN
+        run: yarn deploy $GRAPH_TOKEN $TESTNET_SUBGRAPH

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "codegen": "graph codegen --output-dir src/types/",
     "build": "graph build",
-    "deploy": "graph deploy crisog/alpha-rinkeby-subgraph --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ --access-token"
+    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ --access-token"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.18.0",


### PR DESCRIPTION
Mainnet deployments are only triggered manually, while testnet deployments are triggered on each commit to `master` branch. This will ensure that all candidate production changes will be deployed on Rinkeby first.

This is a temporary workaround, but this will eventually be handled in a different and more efficient way.