### PR TITLE
Calculating APR in a different way

### DIFF
--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -8,6 +8,14 @@ export let ZERO_BIG_DECIMAL = BigDecimal.fromString('0');
 export let ONE_BIG_INT = BigInt.fromI32(1);
 export let ZERO_BIG_INT = BigInt.fromI32(0);
 
+// Time
+export let ONE_MINUTE = BigDecimal.fromString('60'); 
+export let ONE_HOUR = BigDecimal.fromString('60');
+export let ONE_DAY = BigDecimal.fromString('24');
+export let MONTHS_IN_YEAR = BigDecimal.fromString('12');
+export let DAYS_IN_YEAR = BigDecimal.fromString('365.25');
+export let DAYS_IN_MONTH = BigDecimal.fromString('30.25');
+
 // Balancer (sUSD = WPOKT for testing purposes)
 export let WPOKT_DAI_BPOOL = '0x111deccc63846fa4225bbbebaf6f017760acb671';
 export let WPOKT_ADDRESS = '0xf8794ee383b3a265cfbbf456b7cda904c2d1fc6b';

--- a/src/util/helper.ts
+++ b/src/util/helper.ts
@@ -5,7 +5,7 @@ import {
   } from '@graphprotocol/graph-ts';
 import { Token } from '../types/schema';
 import { ERC20 } from '../types/TokenGeyser/ERC20';
-import { ZERO_BIG_DECIMAL, ZERO_BIG_INT } from '../util/constants';
+import { ZERO_BIG_DECIMAL, ZERO_BIG_INT, ONE_MINUTE, ONE_HOUR, ONE_DAY, DAYS_IN_MONTH } from '../util/constants';
 
 export function createNewToken(address: Address): Token {
     let tokenContract = ERC20.bind(address);
@@ -48,3 +48,22 @@ export function createNewToken(address: Address): Token {
     let denom = BigInt.fromI32(10).pow(decimals.toI32() as u8);
     return value.toBigDecimal().div(denom.toBigDecimal());
   }
+
+  export function secondsToDays(
+    seconds: BigInt
+  ): BigDecimal {
+
+    let minutes = seconds.divDecimal(ONE_MINUTE);
+    let hours = minutes.div(ONE_HOUR);
+    let days = hours.div(ONE_DAY);
+    
+    return days;
+  }
+
+export function daysToMonths(
+  days: BigDecimal
+): BigDecimal {
+  let months = days.div(DAYS_IN_MONTH);
+  
+  return months;
+}


### PR DESCRIPTION
To estimate the APR, we were using a formula that used the ownership rate and tried to estimate APR based on the user's situation at that given moment.

In this case, we are using a pool-wide APR because the previous way of calculating it is just too steep.

The new formula is: 
`Unlocked rewards / Total staked * (365/days since farm started)`

